### PR TITLE
Update gitignore to ignore src/builds folder when LV builds the exe's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 *.lvlps
 .cache/
 
+# Builds
+src/builds/
+
 # Python
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update .gitignore to ignore `src/builds/..` folder when LV builds the exe's

### Why should this Pull Request be merged?

- We don't want to add built files to src as those can easily go stale. 
- Also want to minimize the effort for every measurement made to have to change the destination directory for the build files. 

### What testing has been done?

Tested the ignore path with the DMM project currently in main and the `builds` folder is correctly ignored.
