### PR TITLE
Clean up pin map from DCPowerPPS measurement

### DIFF
--- a/src/NIDCPowerPPS/NIDCPowerPPS.pinmap
+++ b/src/NIDCPowerPPS/NIDCPowerPPS.pinmap
@@ -4,23 +4,15 @@
 		<NIDCPowerInstrument name="DCPower1" numberOfChannels="1">
 			<ChannelGroup name="CommonDCPowerChannelGroup" channels="0" />
 		</NIDCPowerInstrument>
-		<NIDCPowerInstrument name="DCPower2" numberOfChannels="1">
-			<ChannelGroup name="CommonDCPowerChannelGroup" channels="0" />
-		</NIDCPowerInstrument>
-		<NIDmmInstrument name="DMM1" />
 	</Instruments>
 	<Pins>
 		<DUTPin name="Pin1" />
-		<DUTPin name="Pin2" />
-		<DUTPin name="DMMPin" />
 	</Pins>
 	<PinGroups></PinGroups>
 	<Sites>
 		<Site siteNumber="0" />
 	</Sites>
 	<Connections>
-		<Connection pin="DMMPin" siteNumber="0" instrument="DMM1" channel="0" />
 		<Connection pin="Pin1" siteNumber="0" instrument="DCPower1" channel="0" />
-		<Connection pin="Pin2" siteNumber="0" instrument="DCPower2" channel="0" />
 	</Connections>
 </PinMap>


### PR DESCRIPTION
### What does this Pull Request accomplish?

- Completing tech debt item to remove additional pins that were left in the pin map that should have been removed. 
- The pin map should only include 1 instrument and 1 pin for consistency across measurements.

### Why should this Pull Request be merged?

- Pin map XML file changes were made to remove unused pins and connections.
- No other files are impacted.

### What testing has been done?

N/A. This isn't a feature functional change.
